### PR TITLE
Atom support and fixed <source> element for validation

### DIFF
--- a/class.phparess.php
+++ b/class.phparess.php
@@ -151,6 +151,9 @@ class phparess_channel {
 
 	private function _tab_rows($string) {
 		$rows = explode("\n", $string);
+
+        $new_rows = array();
+
 		foreach ($rows as $value) {
 			$new_rows[] = "\t" . $value . "\n";
 		}
@@ -298,7 +301,12 @@ class _phparess_xml_tag {
 
 	public function __toString() {
 
+        $attribute_string = "";
+
 		if (count($this->attributes) > 0) {
+
+            $attribute = array();
+
 			foreach ($this->attributes as $key => $value) {
 				$attribute[] = $key . "=\"" . $this->_clear_value($value) . "\"";
 			}


### PR DESCRIPTION
Added atom:link element and special handling of it 
Changed source argument to phparess_item to array instead of string, with two arguments; 
- content (element body) 
- url (element "url" attribute)
